### PR TITLE
Adding app-root-path to look for app root for node modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var sass = require("node-sass");
 var semver = require("semver");
 var css2rn = require("css-to-react-native-transform").default;
 var path = require("path");
+var appRoot = require("app-root-path");
 
 var upstreamTransformer = null;
 
@@ -33,10 +34,7 @@ module.exports.transform = function(src, filename, options) {
   if (filename.endsWith(".scss") || filename.endsWith(".sass")) {
     var result = sass.renderSync({
       data: src,
-      includePaths: [
-        path.dirname(filename),
-        path.dirname(require.main.filename)
-      ]
+      includePaths: [path.dirname(filename), appRoot]
     });
     var css = result.css.toString();
     var cssObject = css2rn(css, { parseMediaQueries: true });

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,8 +134,7 @@
     "app-root-path": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
-      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
-      "dev": true
+      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y="
     },
     "argparse": {
       "version": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "README.md"
   ],
   "dependencies": {
+    "app-root-path": "^2.0.1",
     "css-to-react-native-transform": "^1.4.0",
     "semver": "^5.4.1"
   },


### PR DESCRIPTION
Per issue #7 : how React Native is compiling, it needs to use something other than `path.dirname(require.main.filename)` to get the app root.