### PR TITLE
Add Sass options

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,11 +34,17 @@ module.exports.transform = function(src, filename, options) {
   }
 
   if (filename.endsWith(".scss") || filename.endsWith(".sass")) {
-    var result = sass.renderSync({
+    var defaultOpts = {
       data: src,
       includePaths: [path.dirname(filename), appRoot],
       indentedSyntax: filename.endsWith(".sass")
-    });
+    };
+
+    var opts = options.sassOptions
+      ? Object.assign(options.sassOptions, defaultOpts)
+      : defaultOpts;
+
+    var result = sass.renderSync(opts);
     var css = result.css.toString();
     var cssObject = css2rn(css, { parseMediaQueries: true });
 


### PR DESCRIPTION
Add sassOptions to Sass transformer - Issue: https://github.com/kristerkari/react-native-sass-transformer/issues/2

Example of transformer.js
```
var upstreamTransformer = require("metro/src/reactNativeTransformer");
var sassTransformer = require("react-native-sass-transformer");

module.exports.transform = function({ src, filename, options }) {
  if (filename.endsWith(".scss") || filename.endsWith(".sass")) {
    options.sassOptions = {
      functions: {
        "JS($value)": value => {
          return value;
        }
      }
    };
    let transformed = sassTransformer.transform({ src, filename, options });
    return transformed
  }
  return upstreamTransformer.transform({ src, filename, options });
};
```